### PR TITLE
Add group edit function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem 'font-awesome-sass'
 gem 'devise'
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.0.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -104,6 +105,11 @@ GEM
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.2)
     rack (2.0.8)
     rack-test (0.6.3)
@@ -200,6 +206,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -53,6 +53,10 @@
       color: $sideBarText;
       font-weight: bold;
       margin-bottom: 40px;
+      &__link{
+        text-decoration: none;
+        color: $sideBarText;
+      }
       &__group-name{
         font-size: 15px;
         margin-bottom: 5px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,4 +5,5 @@
 @import "./messages";
 @import "font-awesome-sprockets";
 @import "./font-awesome";
-@import "modules/user"
+@import "modules/user";
+@import "./group";

--- a/app/assets/stylesheets/group.scss
+++ b/app/assets/stylesheets/group.scss
@@ -1,0 +1,107 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+  }
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}
+
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+  &__name {
+    float: left;
+  }
+  &__btn {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,8 @@
 class GroupsController < ApplicationController
   
+  def index
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,8 @@
+class GroupsController < ApplicationController
+  
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,8 +1,22 @@
 class GroupsController < ApplicationController
   
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids: [])
+  end
+
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -14,6 +14,19 @@ class GroupsController < ApplicationController
     end
   end
 
+  def edit
+    @group = Groups.find(params[:id])
+  end
+
+  def update
+    @group = Groups.find(params[:id])
+    if @group.update(group_params)
+      redirect_to root_path, notice: 'グループを更新しました'
+    else
+      render :edit
+    end
+  end
+
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [])

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,5 @@
 class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,2 @@
+class GroupUser < ApplicationRecord
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,2 +1,4 @@
 class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  has_many :group_users
+  has_many :groups, through: :group_users
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,23 @@
+= form_for group do |f|
+  .chat-group-form__errors
+    %h2 10件のエラーが発生しました
+    %ul
+      %li nameを入力してください
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,8 +1,10 @@
 = form_for group do |f|
-  .chat-group-form__errors
-    %h2 10件のエラーが発生しました
-    %ul
-      %li nameを入力してください
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,4 @@
+=form_for @group do |f|
+  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+  = f.collection_check_boxes :user_ids, User.all, :id, :name
+  = f.submit "Save", class: "chat-group-form__action-btn"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,4 +1,3 @@
-=form_for @group do |f|
-  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-  = f.collection_check_boxes :user_ids, User.all, :id, :name
-  = f.submit "Save", class: "chat-group-form__action-btn"
+.chat-group-form
+  %h1 チャットグループ編集
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrapper
+  = render 'messages/side_bar'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,3 @@
-=form_for @group do |f|
-  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-  = f.collection_check_boxes :user_ids, User.all, :id, :name
-  = f.submit "Save", class: "chat-group-form__action-btn"
+.chat-group-form
+  %h1 新規チャットグループ
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,4 @@
+=form_for @group do |f|
+  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+  = f.collection_check_boxes :user_ids, User.all, :id, :name
+  = f.submit "Save", class: "chat-group-form__action-btn"

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -5,7 +5,7 @@
       %ul.main-chat__header__left-box__member-list
         Member：
         %li.main-chat__header__left-box__member   user-name
-    = link_to 'Edit', "#", class:"main-chat__header__edit-btn"
+    = link_to 'Edit', edit_groups_pass, class:"main-chat__header__edit-btn"
 
   .main-chat__message-list
     .main-chat__message-list__message

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -5,7 +5,7 @@
       %ul.main-chat__header__left-box__member-list
         Member：
         %li.main-chat__header__left-box__member   user-name
-    = link_to 'Edit', edit_groups_pass, class:"main-chat__header__edit-btn"
+    = link_to 'Edit', edit_group_path(current_user), class:"main-chat__header__edit-btn"
 
   .main-chat__message-list
     .main-chat__message-list__message

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -5,7 +5,7 @@
         = current_user.name
       %ul.side-bar__header__box__icons
         %li
-          = link_to "#", class:"side-header__box__new-group" do
+          = link_to new_group_path, class:"side-header__box__new-group" do
             = icon('fas', 'edit', class: 'group-edit')
             %span<>
         %li

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -14,9 +14,9 @@
             %span<>
 
   .side-bar__group-list
-    .side-bar__group-list__group
-      %p.side-bar__group-list__group__group-name techcamp
-      %p.side-bar__group-list__group__message まだメッセージがありません
-    .side-bar__group-list__group
-      %p.side-bar__group-list__group__group-name techcamp
-      %p.side-bar__group-list__group__message まだメッセージがありません
+    - current_user.groups.each do |group|
+      .side-bar__group-list__group
+        = link_to '#', class:"side-bar__group-list__group__link" do
+          %p.side-bar__group-list__group__group-name
+            = group.name
+          %p.side-bar__group-list__group__message まだメッセージがありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "messages#index"
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "messages#index"
+  root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create]
+  resources :groups, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20200115082547_create_groups.rb
+++ b/db/migrate/20200115082547_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200115082607_create_group_users.rb
+++ b/db/migrate/20200115082607_create_group_users.rb
@@ -1,0 +1,9 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115041710) do
+ActiveRecord::Schema.define(version: 20200115082607) do
+
+  create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_group_users_on_user_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false
@@ -26,4 +42,6 @@ ActiveRecord::Schema.define(version: 20200115041710) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end


### PR DESCRIPTION
#What
groupのモデル及びコントローラーを作成し、グループの新規登録、編集ができるようにした。
その際、usersテーブルとgruopsテーブルを、中間テーブルを使ってアソシエーションを設定した。
また、groupのindexアクションとビューを作成し、root_pathに設定した。
なお、group編集画面の確認はできていない。

#Why
group編集画面の確認については、groupのidが必要であり、現時点ではそれが取得できないため。